### PR TITLE
Fix usage of message attr in Exception object

### DIFF
--- a/sourcemap/decoder.py
+++ b/sourcemap/decoder.py
@@ -215,9 +215,10 @@ class SourceMapDecoder(object):
                     assert src_line >= 0, ('src_line', src_line)
                     assert src_col >= 0, ('src_col', src_col)
                 except AssertionError as e:
+                    error_info = e.args[0]
                     raise SourceMapDecodeError(
                         "Segment %s has negative %s (%d), in file %s"
-                        % (segment, e.message[0], e.message[1], src)
+                        % (segment, error_info[0], error_info[1], src)
                     )
 
                 token = Token(dst_line, dst_col, src, src_line, src_col, name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,3 +65,13 @@ class IntegrationTestCase(unittest.TestCase):
 
         # This shouldn't blow up
         sourcemap.loads(min_map)
+
+    def test_invalid_map(self):
+        with self.assertRaises(
+            sourcemap.SourceMapDecodeError,
+            msg='Segment LCnBD has negative dst_col (-5), in file test-invalid2.js'
+        ):
+            sourcemap.loads(
+                '{"version":3,"lineCount":1,"mappings":"LCnBD;",'
+                '"sources":["test-invalid.js","test-invalid2.js"],"names":[]}'
+            )


### PR DESCRIPTION
In Python 3, the `message` attribute has been removed from `Exception` and we're expected to obtain its string representation by invoking `str` on it, eg. `str(exc)`.

In this case, since what's being captured is an `AssertionError`, message becomes a list where the second element contains the message passed to `assert`.

We can use `args` to access this which works on both Pythons.

I've also added tests triggering this assertion condition by passing an invalid sourcemap.

---
### Tests ran in Python 2.7
```py
❯ pytest tests
============================ test session starts ============================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
rootdir: /Users/matux/code/rollbar/python-sourcemap
collected 17 items

tests/test_init.py ...                                                 [ 17%]
tests/test_integration.py ....                                         [ 41%]
tests/test_objects.py ..........                                       [100%]

============================ 17 passed in 0.12 seconds ======================
```
### Tests ran in Python 3.10
```py
❯ pytest tests
============================ test session starts ============================
platform darwin -- Python 3.10.14, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/matux/code/rollbar/python-sourcemap
collected 17 items

tests/test_init.py ...                                                 [ 17%]
tests/test_integration.py ....                                         [ 41%]
tests/test_objects.py ..........                                       [100%]

============================ 17 passed in 0.07s =============================
```