### PR TITLE
Dmilgram/invalid sources - raise custom error

### DIFF
--- a/sourcemap/__init__.py
+++ b/sourcemap/__init__.py
@@ -8,7 +8,7 @@ sourcemap
 from .exceptions import SourceMapDecodeError  # NOQA
 from .decoder import SourceMapDecoder
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 def load(fp, cls=None):

--- a/sourcemap/decoder.py
+++ b/sourcemap/decoder.py
@@ -13,7 +13,7 @@ Original source under Apache license, see:
 import os
 import sys
 from functools import partial
-from .exceptions import SourceMapDecodeError
+from .exceptions import SourceMapDecodeError, SourceMapInvalidError
 from .objects import Token, SourceMapIndex, SectionedSourceMapIndex
 try:
     import simplejson as json
@@ -148,6 +148,9 @@ class SourceMapDecoder(object):
 
     def _decode_map(self, smap):
         sources = smap['sources']
+        if not all(isinstance(item, str) for item in sources):
+            raise SourceMapInvalidError("Sources must be a list of strings")
+
         sourceRoot = smap.get('sourceRoot')
         names = list(map(text_type, smap['names']))
         mappings = smap['mappings']

--- a/sourcemap/decoder.py
+++ b/sourcemap/decoder.py
@@ -13,7 +13,7 @@ Original source under Apache license, see:
 import os
 import sys
 from functools import partial
-from .exceptions import SourceMapDecodeError, SourceMapInvalidError
+from .exceptions import SourceMapDecodeError, SourceMapTypeError
 from .objects import Token, SourceMapIndex, SectionedSourceMapIndex
 try:
     import simplejson as json
@@ -149,7 +149,7 @@ class SourceMapDecoder(object):
     def _decode_map(self, smap):
         sources = smap['sources']
         if not all(isinstance(item, str) for item in sources):
-            raise SourceMapInvalidError("Sources must be a list of strings")
+            raise SourceMapTypeError("Sources must be a list of strings")
 
         sourceRoot = smap.get('sourceRoot')
         names = list(map(text_type, smap['names']))

--- a/sourcemap/exceptions.py
+++ b/sourcemap/exceptions.py
@@ -8,3 +8,7 @@ sourcemap.exceptions
 class SourceMapDecodeError(ValueError):
     "lol sourcemap error"
     pass
+
+class SourceMapInvalidError(TypeError):
+    "invalid sourcemap due to a type error"
+    pass

--- a/sourcemap/exceptions.py
+++ b/sourcemap/exceptions.py
@@ -9,6 +9,6 @@ class SourceMapDecodeError(ValueError):
     "lol sourcemap error"
     pass
 
-class SourceMapInvalidError(TypeError):
+class SourceMapTypeError(TypeError):
     "invalid sourcemap due to a type error"
     pass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,3 +75,12 @@ class IntegrationTestCase(unittest.TestCase):
                 '{"version":3,"lineCount":1,"mappings":"LCnBD;",'
                 '"sources":["test-invalid.js","test-invalid2.js"],"names":[]}'
             )
+
+    def test_invalid_map_type_error(self):
+        with self.assertRaises(
+            sourcemap.exceptions.SourceMapTypeError,
+            msg='Sources must be a list of strings'
+        ):
+            sourcemap.loads(
+                '{"version":3,"sources":["1", "2", 3],"names":["x","alert"],"mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM"}'
+            )


### PR DESCRIPTION
## Description of the change

> We are seeing [this Rollbar issue ](https://app.rollbar.com/a/Rollbar/fix/item/source-map-download-worker/89844) due to invalid source maps with non string values inside the `sources` array. So from our fork we want to raise a custom error that will be handled from the mox side, letting the user know about their wrong sourcemap.

![image](https://github.com/user-attachments/assets/acc54075-d14d-48e6-98f8-3b0d9c1492e6)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)

## Related issues

> [this Rollbar issue ](https://app.rollbar.com/a/Rollbar/fix/item/source-map-download-worker/89844)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
